### PR TITLE
Fixing dead loop on select

### DIFF
--- a/internal/db/pg.go
+++ b/internal/db/pg.go
@@ -49,7 +49,7 @@ func (t *ReadTable) Query(limit int64) string {
 	}
 	query := fmt.Sprintf("select * from %s%s;", t.Name, limitQuery)
 	if t.query != "" {
-		query = fmt.Sprintf(t.query, limit)
+		query = fmt.Sprintf(t.query, limitQuery)
 	}
 
 	return query


### PR DESCRIPTION
The select {} in the read layer only selected the first entity in the channel, thereby preventing the reader from progressing.
A loop construct to be able to properly loop through all the data has been added.

PS: The use of goto here is both ok, and within idiomatic go code, so no complaints!