### PR TITLE
Remove redundant checks

### DIFF
--- a/internal/conf/configuration.go
+++ b/internal/conf/configuration.go
@@ -97,7 +97,7 @@ func (layer *Datalayer) GetUrl(postMapping *PostMapping, tableMapping *TableMapp
 			scheme = "postgresql"
 		}
 
-		if postMapping != nil && postMapping.Config != nil {
+		if postMapping.Config != nil {
 			if postMapping.Config.Schema != nil {
 				scheme = *postMapping.Config.Schema
 			}
@@ -135,7 +135,7 @@ func (layer *Datalayer) GetUrl(postMapping *PostMapping, tableMapping *TableMapp
 			scheme = "postgresql"
 		}
 
-		if tableMapping != nil && tableMapping.Config != nil {
+		if tableMapping.Config != nil {
 			if tableMapping.Config.Schema != nil {
 				scheme = *tableMapping.Config.Schema
 			}


### PR DESCRIPTION
The `if postMapping != nil` check on line 100 is inside a block that already checked for `if postMapping != nil` on line 89.

The `if tableMapping != nil` check on line 138 is inside a block that already checked for `else if tableMapping != nil` on line 127.