### PR TITLE
chore: fix FromAsCasing warnings when building docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine3.19 AS builder
+FROM golang:1.22.6-alpine3.19 AS builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine3.19 as builder
+FROM golang:1.22.2-alpine3.19 AS builder
 
 # Install git + SSL ca certificates.
 # Git is required for fetching the dependencies.
@@ -15,7 +15,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 #####################################################################################################
-FROM builder as build
+FROM builder AS build
 
 # Copy the source from the current directory to the Working Directory inside the container
 COPY cmd ./cmd 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mimiro-io/postgresql-datalayer
 
-go 1.22.2
+go 1.22.6
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.1.1


### PR DESCRIPTION
Since recent Docker versions [run build checks by default](https://docs.docker.com/build/checks/#build-with-checks) when building, we should fix this annoying warning when building the docker container

```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 18)                                                                                                         0.0s
```

Also fixes these trivy-detected issues by upgrading the go version


```
 Total: 2 (HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.2            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24788 │ HIGH     │        │                   │ 1.22.3          │ golang: net: malformed DNS message can cause infinite loop │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24788                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```